### PR TITLE
Fix issue with header resize

### DIFF
--- a/portfolio_index_styles.css
+++ b/portfolio_index_styles.css
@@ -90,8 +90,12 @@ body {
 
 
 /**************************************** Header */
-header{
+header {
 	padding-bottom: 0 !important;
+	position: sticky !important;
+	position: -webkit-sticky !important;
+	top: 0;
+	left:0;
 }
 
 header h4{
@@ -129,9 +133,7 @@ header h4{
 
 #header_is_compressed {
 	width: 30% !important;
-	position: fixed;
-	top: 0;
-	left: 0;
+	margin-right: 70%;
 }
 
 #header_is_compressed #header_title{
@@ -460,6 +462,10 @@ footer{
 @media only screen and (max-width: 1150px) {
 	#quickfind_column {
 		display: none;
+	}
+
+	header{
+		position: static !important;
 	}
 
 	#main_column {


### PR DESCRIPTION
*fixed an issue with the header resize interfering with the quickfind when used at the top of the page, this was because the header was being moved and therefore changing the scroll of the page at the same time that the quickfind heading was pressed, thus offesting where the page scrolled to
*fixed this by changing the header to be sticky instead of fixed
*not only did this fix the issue but now the feature is even smoother than before